### PR TITLE
Add WEBCLONER landing page replica

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WEBCLONER</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="noise-layer" aria-hidden="true"></div>
+  <main class="hero">
+    <div class="badge">Цены от 3.75$</div>
+    <div class="title-group">
+      <div class="logo-icon" aria-hidden="true">
+        <div class="sheet"></div>
+        <div class="corner"></div>
+      </div>
+      <h1 class="title">WEBCLONER</h1>
+    </div>
+    <p class="subtitle">Авто-копирование лендингов за минуту</p>
+  </main>
+  <canvas class="particle-canvas" aria-hidden="true"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,70 @@
+const canvas = document.querySelector('.particle-canvas');
+const ctx = canvas.getContext('2d');
+
+function resize() {
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  draw();
+}
+
+const cards = [
+  { x: 120, y: 120, w: 150, h: 80, glow: 'rgba(255,255,255,0.08)' },
+  { x: 420, y: 200, w: 180, h: 90, glow: 'rgba(80,130,255,0.12)' },
+  { x: 220, y: 420, w: 150, h: 80, glow: 'rgba(255,255,255,0.1)' },
+  { x: window.innerWidth - 320, y: 140, w: 170, h: 90, glow: 'rgba(90,120,255,0.14)' },
+  { x: window.innerWidth - 460, y: 420, w: 160, h: 80, glow: 'rgba(255,255,255,0.07)' },
+  { x: window.innerWidth / 2 - 90, y: window.innerHeight - 180, w: 180, h: 90, glow: 'rgba(70,90,200,0.16)' }
+];
+
+function drawCard(card) {
+  ctx.save();
+  ctx.translate(card.x, card.y);
+  ctx.fillStyle = card.glow;
+  ctx.shadowColor = card.glow;
+  ctx.shadowBlur = 80;
+  ctx.fillRect(0, 0, card.w, card.h);
+
+  ctx.fillStyle = 'rgba(8, 11, 18, 0.78)';
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.6)';
+  ctx.shadowBlur = 40;
+  ctx.beginPath();
+  const radius = 16;
+  const { w, h } = card;
+  ctx.moveTo(radius, 0);
+  ctx.lineTo(w - radius, 0);
+  ctx.quadraticCurveTo(w, 0, w, radius);
+  ctx.lineTo(w, h - radius);
+  ctx.quadraticCurveTo(w, h, w - radius, h);
+  ctx.lineTo(radius, h);
+  ctx.quadraticCurveTo(0, h, 0, h - radius);
+  ctx.lineTo(0, radius);
+  ctx.quadraticCurveTo(0, 0, radius, 0);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.18)';
+  ctx.fillRect(24, 24, w - 48, 10);
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.12)';
+  ctx.fillRect(24, 46, (w - 48) * 0.65, 8);
+  ctx.restore();
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  cards.forEach(drawCard);
+}
+
+window.addEventListener('resize', () => {
+  cards[3].x = window.innerWidth - 320;
+  cards[4].x = window.innerWidth - 460;
+  cards[5].x = window.innerWidth / 2 - 90;
+  cards[5].y = window.innerHeight - 180;
+  resize();
+});
+
+resize();
+
+document.body.classList.add('is-loaded');

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,174 @@
+:root {
+  color-scheme: dark;
+  --bg: #050507;
+  --bg-grad-1: #090b12;
+  --bg-grad-2: #0b0d16;
+  --accent: #ffffff;
+  --accent-dim: rgba(255, 255, 255, 0.12);
+  --accent-glow: rgba(76, 132, 255, 0.45);
+  --badge-shadow: rgba(0, 0, 0, 0.6);
+  --title-shadow: rgba(0, 0, 0, 0.75);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Montserrat", "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top right, rgba(31, 47, 94, 0.28), transparent 55%),
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.08), transparent 40%),
+    radial-gradient(circle at 80% 80%, rgba(66, 84, 153, 0.22), transparent 60%),
+    radial-gradient(circle at center, rgba(17, 17, 17, 0.85), transparent 75%),
+    linear-gradient(135deg, var(--bg-grad-1), var(--bg-grad-2));
+  color: var(--accent);
+  overflow: hidden;
+  position: relative;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: -20vmax;
+  background-image: repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.03) 0,
+      rgba(255, 255, 255, 0.03) 1px,
+      transparent 1px,
+      transparent 3px
+    ),
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.02) 0,
+      rgba(255, 255, 255, 0.02) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+  opacity: 0.15;
+  pointer-events: none;
+  mix-blend-mode: soft-light;
+  z-index: 0;
+}
+
+body::after {
+  background-image: radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.15), transparent 45%),
+    radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.07), transparent 55%),
+    radial-gradient(circle at 65% 75%, rgba(255, 255, 255, 0.05), transparent 65%);
+  filter: blur(30px);
+  opacity: 0.25;
+}
+
+.hero {
+  position: relative;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1.25rem, 2vw, 1.75rem);
+  padding: clamp(3rem, 6vw, 4.5rem) clamp(2rem, 4vw, 3rem);
+  border-radius: clamp(2rem, 4vw, 3rem);
+  backdrop-filter: blur(22px);
+  background: linear-gradient(135deg, rgba(17, 20, 29, 0.82), rgba(7, 8, 11, 0.55));
+  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  z-index: 1;
+}
+
+.badge {
+  font-size: clamp(0.85rem, 1.8vw, 1rem);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.9);
+  color: #11131a;
+  padding: 0.4rem 1.8rem;
+  border-radius: 999px;
+  box-shadow: 0 12px 30px var(--badge-shadow);
+}
+
+.title-group {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 2vw, 1.4rem);
+}
+
+.logo-icon {
+  width: clamp(3rem, 6vw, 4rem);
+  height: clamp(3.6rem, 7vw, 4.8rem);
+  border-radius: 1rem;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0.04));
+  position: relative;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.12), 0 20px 35px rgba(0, 0, 0, 0.45);
+  display: grid;
+  place-items: center;
+}
+
+.logo-icon .sheet {
+  width: 55%;
+  height: 70%;
+  border-radius: 0.6rem;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(220, 225, 238, 0.5));
+  position: relative;
+}
+
+.logo-icon .sheet::after {
+  content: "";
+  position: absolute;
+  inset: 25% 15% auto auto;
+  width: 45%;
+  height: 35%;
+  border-radius: 0.4rem;
+  background: rgba(14, 25, 45, 0.28);
+}
+
+.logo-icon .corner {
+  position: absolute;
+  bottom: 0.65rem;
+  right: 0.55rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 0.35rem;
+  background: linear-gradient(145deg, rgba(34, 47, 80, 0.85), rgba(11, 14, 21, 0.6));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.title {
+  font-weight: 800;
+  letter-spacing: 0.32em;
+  font-size: clamp(2.8rem, 8vw, 5rem);
+  text-shadow: 0 18px 38px var(--title-shadow);
+}
+
+.subtitle {
+  font-weight: 400;
+  font-size: clamp(1.05rem, 2.4vw, 1.4rem);
+  color: rgba(255, 255, 255, 0.8);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.particle-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 0;
+  filter: blur(1px);
+  opacity: 0.6;
+}
+
+@media (max-width: 520px) {
+  .title {
+    letter-spacing: 0.24em;
+  }
+
+  .subtitle {
+    letter-spacing: 0.08em;
+  }
+}

--- a/theme.tss
+++ b/theme.tss
@@ -1,0 +1,21 @@
+// Theme style sheet for WEBCLONER landing hero
+// This optional layer documents the color and spacing tokens
+// used in styles.css so that the UI can be re-used in other stacks.
+{
+  "colors": {
+    "background": "#050507",
+    "primaryAccent": "#ffffff",
+    "badgeForeground": "#11131a",
+    "badgeBackground": "rgba(255,255,255,0.9)",
+    "cardGlow": "rgba(76,132,255,0.45)"
+  },
+  "fonts": {
+    "primary": "Montserrat",
+    "fallbacks": ["Segoe UI", "sans-serif"]
+  },
+  "radii": {
+    "hero": "3rem",
+    "badge": "999px",
+    "card": "1rem"
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page WEBCLONER hero layout that matches the provided artwork
- style the page with gradients, glassmorphism and responsive typography to mirror the composition
- render subtle floating UI cards with canvas to emulate the blurred background elements and document tokens in a TSS theme file

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d36d62a96c832a847afaa22a6d62db